### PR TITLE
Add time to waypoints and fix bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ end
 
 Exporting an ActiveRecord to GPXFile (as Waypoints)
 ```ruby
-    #
-    # Our active record in this example is called stop
-    #
-    
- # models/stop.rb 
- class Stop < ActiveRecord::Base
+#
+# Our active record in this example is called stop
+#
+ 
+# models/stop.rb 
+class Stop < ActiveRecord::Base
    # This model has the following attributes:
    # name
    # lat
@@ -56,7 +56,8 @@ Exporting an ActiveRecord to GPXFile (as Waypoints)
      gpx.to_s
    end
  end # class
-   
+
+
 # controllers/stops.rb
 def index 
    @stops = Stop.all
@@ -65,16 +66,17 @@ def index
     format.gpx { send_data @stops.to_gpx, filename: controller_name + '.gpx' }
    end
 end
-  
+
+
 # Add this line to config/initializers/mime_types.rb
 Mime::Type.register "application/gpx+xml", :gpx
   
-# 
+ 
 # To get the xml file:
-#  http://localhost:3000/stops.gpx
+#   http://localhost:3000/stops.gpx
 ```
 
-You have a complete example on how to create a GPX file from scratch on the `tests/output_text.rb` file.
+You have a complete example on how to create a gpx file from scratch on `tests/output_text.rb`.
 
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-= GPX Gem
+# GPX Gem
 
 {<img src="https://travis-ci.org/andrewhao/gpx.svg" alt="Build Status" />}[https://travis-ci.org/andrewhao/gpx]
 
 Copyright (C) 2006 Doug Fales mailto:doug@falesafeconsulting.com
 
-== What It Does
+## What It Does
 
 This library reads GPX files and provides an API for reading and manipulating
 the data as objects.  For more info on the GPX format, see
@@ -16,21 +16,24 @@ rectangular areas within a file, and it also calculates some meta-data about
 the tracks and points in a file (such as distance, duration, average speed,
 etc).
 
-== Examples
+## Examples
 
 Reading a GPX file, and cropping its contents to a given area:
-         gpx =  GPX::GPXFile.new(:gpx_file => filename)   # Read GPX file
-         bounds = GPX::Bounds.new(params)                 # Create a rectangular area to crop
-         gpx.crop(bounds)                                 # Crop it
-         gpx.write(filename)                              # Save it
+```ruby
+gpx =  GPX::GPXFile.new(:gpx_file => filename)   # Read GPX file
+bounds = GPX::Bounds.new(params)                 # Create a rectangular area to crop
+gpx.crop(bounds)                                 # Crop it
+gpx.write(filename)                              # Save it
+```
 
 Converting a Magellan track log to GPX:
-      if GPX::MagellanTrackLog::is_magellan_file?(filename)
-         GPX::MagellanTrackLog::convert_to_gpx(filename, "#{filename}.gpx")
-      end
+```ruby
+if GPX::MagellanTrackLog::is_magellan_file?(filename)
+ GPX::MagellanTrackLog::convert_to_gpx(filename, "#{filename}.gpx")
+end
 
 Exporting an ActiveRecord to GPXFile (as Waypoints)
-
+```ruby
     #
     # Our active record in this example is called stop
     #
@@ -68,12 +71,12 @@ Exporting an ActiveRecord to GPXFile (as Waypoints)
     # 
     # To get the xml file:
     #  http://localhost:3000/stops.gpx
-
+```
 
 You have a complete example on how to create a GPX file from scratch on the `tests/output_text.rb` file.
 
 
-== Notes
+## Notes
 
 This library was written to bridge the gap between my Garmin Geko
 and my website, WalkingBoss.org (RIP).  For that reason, it has always been more of a

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # GPX Gem
 
-{<img src="https://travis-ci.org/andrewhao/gpx.svg" alt="Build Status" />}[https://travis-ci.org/andrewhao/gpx]
+[<img src="https://travis-ci.org/andrewhao/gpx.svg" alt="Build Status" />](https://travis-ci.org/andrewhao/gpx)
 
-Copyright (C) 2006 Doug Fales mailto:doug@falesafeconsulting.com
+Copyright (C) 2006 Doug Fales doug@falesafeconsulting.com
 
 ## What It Does
 
@@ -31,6 +31,7 @@ Converting a Magellan track log to GPX:
 if GPX::MagellanTrackLog::is_magellan_file?(filename)
  GPX::MagellanTrackLog::convert_to_gpx(filename, "#{filename}.gpx")
 end
+```
 
 Exporting an ActiveRecord to GPXFile (as Waypoints)
 ```ruby
@@ -38,39 +39,39 @@ Exporting an ActiveRecord to GPXFile (as Waypoints)
     # Our active record in this example is called stop
     #
     
-    # models/stop.rb 
-    class Stop < ActiveRecord::Base
-      # This model has the following attributes:
-      # name
-      # lat
-      # lon
-      # updated_at
-    
-      def self.to_gpx
-        require 'GPX'
-        gpx = GPX::GPXFile.new
-        all.each do |stop|
-          gpx.waypoints << GPX::Waypoint.new({name: stop.name, lat: stop.lat, lon: stop.lon, time: stop.updated_at})
-        end 
-        gpx.to_s
-      end
-    end # class
-    
-    # controllers/stops.rb
-    def index 
-      @stops = Stop.all
-      respond_to do |format|
-        format.html {render :index}
-        format.gpx { send_data @stops.to_gpx, filename: controller_name + '.gpx' }
-      end
-    end
-    
-    # Add this line to config/initializers/mime_types.rb
-    Mime::Type.register "application/gpx+xml", :gpx
-    
-    # 
-    # To get the xml file:
-    #  http://localhost:3000/stops.gpx
+ # models/stop.rb 
+ class Stop < ActiveRecord::Base
+   # This model has the following attributes:
+   # name
+   # lat
+   # lon
+   # updated_at
+   
+   def self.to_gpx
+     require 'GPX'
+     gpx = GPX::GPXFile.new
+     all.each do |stop|
+       gpx.waypoints << GPX::Waypoint.new({name: stop.name, lat: stop.lat, lon: stop.lon, time: stop.updated_at})
+     end 
+     gpx.to_s
+   end
+ end # class
+   
+# controllers/stops.rb
+def index 
+   @stops = Stop.all
+   respond_to do |format|
+    format.html {render :index}
+    format.gpx { send_data @stops.to_gpx, filename: controller_name + '.gpx' }
+   end
+end
+  
+# Add this line to config/initializers/mime_types.rb
+Mime::Type.register "application/gpx+xml", :gpx
+  
+# 
+# To get the xml file:
+#  http://localhost:3000/stops.gpx
 ```
 
 You have a complete example on how to create a GPX file from scratch on the `tests/output_text.rb` file.

--- a/README.rdoc
+++ b/README.rdoc
@@ -29,6 +29,49 @@ Converting a Magellan track log to GPX:
          GPX::MagellanTrackLog::convert_to_gpx(filename, "#{filename}.gpx")
       end
 
+Exporting an ActiveRecord to GPXFile (as Waypoints)
+
+    #
+    # Our active record in this example is called stop
+    #
+    
+    # models/stop.rb 
+    class Stop < ActiveRecord::Base
+      # This model has the following attributes:
+      # name
+      # lat
+      # lon
+      # updated_at
+    
+      def self.to_gpx
+        require 'GPX'
+        gpx = GPX::GPXFile.new
+        all.each do |stop|
+          gpx.waypoints << GPX::Waypoint.new({name: stop.name, lat: stop.lat, lon: stop.lon, time: stop.updated_at})
+        end 
+        gpx.to_s
+      end
+    end # class
+    
+    # controllers/stops.rb
+    def index 
+      @stops = Stop.all
+      respond_to do |format|
+        format.html {render :index}
+        format.gpx { send_data @stops.to_gpx, filename: controller_name + '.gpx' }
+      end
+    end
+    
+    # Add this line to config/initializers/mime_types.rb
+    Mime::Type.register "application/gpx+xml", :gpx
+    
+    # 
+    # To get the xml file:
+    #  http://localhost:3000/stops.gpx
+
+
+You have a complete example on how to create a GPX file from scratch on the `tests/output_text.rb` file.
+
 
 == Notes
 

--- a/lib/gpx/gpx_file.rb
+++ b/lib/gpx/gpx_file.rb
@@ -253,7 +253,7 @@ module GPX
       
       gpx_header['version'] = @version.to_s if !gpx_header['version']
       gpx_header['creator'] = DEFAULT_CREATOR if !gpx_header['creator']
-      gpx_header['xsi:schemaLocation'] = "http://www.topografix.com/GPX/#{version_dir} http://www.topografix.com/GPX/#{version_dir}/gpx.xsd" if !gpx_header['xsi:schemaLocation']
+      gpx_header['xmlns:xsi:schemaLocation'] = "http://www.topografix.com/GPX/#{version_dir} http://www.topografix.com/GPX/#{version_dir}/gpx.xsd" if !gpx_header['xsi:schemaLocation'] and !gpx_header['xmlns:xsi:schemaLocation']
       gpx_header['xsi'] = "http://www.w3.org/2001/XMLSchema-instance" if !gpx_header['xsi'] and !gpx_header['xmlns:xsi']
       
       #$stderr.puts gpx_header.keys.inspect

--- a/lib/gpx/gpx_file.rb
+++ b/lib/gpx/gpx_file.rb
@@ -253,7 +253,7 @@ module GPX
       
       gpx_header['version'] = @version.to_s if !gpx_header['version']
       gpx_header['creator'] = DEFAULT_CREATOR if !gpx_header['creator']
-      gpx_header['xmlns:xsi:schemaLocation'] = "http://www.topografix.com/GPX/#{version_dir} http://www.topografix.com/GPX/#{version_dir}/gpx.xsd" if !gpx_header['xsi:schemaLocation'] and !gpx_header['xmlns:xsi:schemaLocation']
+      gpx_header['xsi:schemaLocation'] = "http://www.topografix.com/GPX/#{version_dir} http://www.topografix.com/GPX/#{version_dir}/gpx.xsd" if !gpx_header['xsi:schemaLocation']
       gpx_header['xsi'] = "http://www.w3.org/2001/XMLSchema-instance" if !gpx_header['xsi'] and !gpx_header['xmlns:xsi']
       
       #$stderr.puts gpx_header.keys.inspect

--- a/lib/gpx/gpx_file.rb
+++ b/lib/gpx/gpx_file.rb
@@ -254,7 +254,7 @@ module GPX
       gpx_header['version'] = @version.to_s if !gpx_header['version']
       gpx_header['creator'] = DEFAULT_CREATOR if !gpx_header['creator']
       gpx_header['xsi:schemaLocation'] = "http://www.topografix.com/GPX/#{version_dir} http://www.topografix.com/GPX/#{version_dir}/gpx.xsd" if !gpx_header['xsi:schemaLocation']
-      gpx_header['xsi'] = "http://www.w3.org/2001/XMLSchema-instance" if !gpx_header['xsi'] and !gpx_header['xmlns:xsi']
+      gpx_header['xmlns:xsi'] = "http://www.w3.org/2001/XMLSchema-instance" if !gpx_header['xsi'] and !gpx_header['xmlns:xsi']
       
       #$stderr.puts gpx_header.keys.inspect
 

--- a/lib/gpx/gpx_file.rb
+++ b/lib/gpx/gpx_file.rb
@@ -205,7 +205,7 @@ module GPX
       @time = Time.now if(@time.nil? or update_time)
       @name ||= File.basename(filename)
       doc = generate_xml_doc
-      File.open(filename, 'w') { |f| f.write(doc.to_xml) }
+      File.open(filename, 'w+') { |f| f.write(doc.to_xml) }
     end
 
     def to_s(update_time = true)
@@ -304,6 +304,7 @@ module GPX
 
             waypoints.each do |w|
               xml.wpt(lat: w.lat, lon: w.lon) {
+                xml.time w.time.xmlschema unless w.time.nil?
                 Waypoint::SUB_ELEMENTS.each do |sub_elem|
                   xml.send(sub_elem, w.send(sub_elem)) if w.respond_to?(sub_elem) && !w.send(sub_elem).nil?
                 end

--- a/lib/gpx/waypoint.rb
+++ b/lib/gpx/waypoint.rb
@@ -25,7 +25,7 @@ module GPX
   # not seen much use yet, since WalkingBoss does not use waypoints right now.
   class Waypoint < Point
 
-    SUB_ELEMENTS = %w{ magvar geoidheight name cmt desc src link sym type fix sat hdop vdop pdop ageofdgpsdata dgpsid extensions ele}
+    SUB_ELEMENTS = %w{ele magvar geoidheight name cmt desc src link sym type fix sat hdop vdop pdop ageofdgpsdata dgpsid extensions}
 
     attr_reader :gpx_file
     SUB_ELEMENTS.each { |sub_el| attr_accessor sub_el.to_sym }

--- a/tests/gpx_files/waypoints.gpx
+++ b/tests/gpx_files/waypoints.gpx
@@ -17,4 +17,6 @@
 <wpt lat="39.999840" lon="-105.214696"><name><![CDATA[SBDR]]></name><sym>Waypoint</sym><ele>1612.965</ele></wpt>
 <wpt lat="39.989739" lon="-105.295285"><name><![CDATA[TO]]></name><sym>Waypoint</sym><ele>2163.556</ele></wpt>
 <wpt lat="40.035301" lon="-105.254443"><name><![CDATA[VICS]]></name><sym>Waypoint</sym><ele>1535.34</ele></wpt>
+<wpt lat="8.992441" lon="-79.530365"><time>2015-01-01T12:12:12Z</time><name>loma la pava ???</name><desc>Mar 22, 2015, 10:46:17</desc>
+</wpt>
 </gpx>

--- a/tests/output_test.rb
+++ b/tests/output_test.rb
@@ -42,7 +42,8 @@ class OutputTest < Minitest::Test
           {:lat => 25.061783, :lon => 121.640267,  :name => 'GRMTWN', :sym => 'Waypoint', :ele => '38.09766'},
           {:lat => 39.999840, :lon => -105.214696, :name => 'SBDR',   :sym => 'Waypoint', :ele => '1612.965'},
           {:lat => 39.989739, :lon => -105.295285, :name => 'TO',     :sym => 'Waypoint', :ele => '2163.556'},
-          {:lat => 40.035301, :lon => -105.254443, :name => 'VICS',   :sym => 'Waypoint', :ele => '1535.34'}
+          {:lat => 40.035301, :lon => -105.254443, :name => 'VICS',   :sym => 'Waypoint', :ele => '1535.34'},
+          {:lat => 40.035301, :lon => -105.254443, :name => 'TIMEDWPT',   :sym => 'Waypoint', :ele => '1535.34', :time => Time.parse("2005-12-31T22:05:09Z")}
         ]
 	
 	waypoint_data.each do |wpt_hash|

--- a/tests/waypoint_test.rb
+++ b/tests/waypoint_test.rb
@@ -6,7 +6,7 @@ class WaypointTest < Minitest::Test
   def test_read_waypoints
 
     gpx = GPX::GPXFile.new(:gpx_file => File.join(File.dirname(__FILE__), "gpx_files/waypoints.gpx"))
-    assert_equal(17, gpx.waypoints.size)
+    assert_equal(18, gpx.waypoints.size)
 
     #    First Waypoint
     #   <wpt lat="40.035557" lon="-105.248268">
@@ -38,7 +38,11 @@ class WaypointTest < Minitest::Test
     assert_equal('002', second_wpt.name)
     assert_equal('Waypoint', second_wpt.sym)
     assert_equal(1955.192, second_wpt.elevation)
-
+    
+    # test loads time properly in waypoint
+    time_wpt = gpx.waypoints[17]
+    assert_equal(Time.xmlschema("2015-01-01T12:12:12Z"), time_wpt.time)
+    
   end
 end
 


### PR DESCRIPTION
Hi!

I was trying to use this gem in a project and I found some issues:
- Waypoints did not include time element
- There was a problem in GPXFile.write
- While trying to upload the output of the GPX file to open street maps (web editor), it required to add xmlns to xsi attribute.

Also, I added some doc about how to create a gpx file on the readme. In my case I was not interested in parsing the file but in exporting some active record data.

I read you tried to contact the original author, did you get any response about the license?

Thanks
Best, Juan.
